### PR TITLE
docs: widget README + curl smoke script

### DIFF
--- a/examples/smoke.sh
+++ b/examples/smoke.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# ARR REST API smoke test (curl + jq)
+#
+# Prerequisites:
+#   - arr-mcp server running: node packages/arr-mcp/dist/index.js --transport http
+#   - jq installed: https://jqlang.github.io/jq/
+#   - Ed25519 keypair (generated below via openssl)
+#
+# Usage:
+#   chmod +x examples/smoke.sh
+#   ./examples/smoke.sh
+
+set -euo pipefail
+
+BASE="http://127.0.0.1:8787"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ── Generate Ed25519 keypair ─────────────────────────────────────
+openssl genpkey -algorithm ed25519 -out "$TMPDIR/private.pem" 2>/dev/null
+openssl pkey -in "$TMPDIR/private.pem" -pubout -out "$TMPDIR/public.pem" 2>/dev/null
+
+PRIVATE_KEY=$(cat "$TMPDIR/private.pem")
+PUBLIC_KEY=$(cat "$TMPDIR/public.pem")
+
+# Creator ID from public key (the server derives this; we pass it as-is for drafts)
+CREATOR="smoke-test-$(date +%s)"
+
+echo "=== ARR REST smoke test ==="
+echo ""
+
+# ── 1. Subscribe to SSE events (background) ─────────────────────
+echo "[sse] Listening on $BASE/events ..."
+curl -sN "$BASE/events" > "$TMPDIR/events.log" 2>/dev/null &
+SSE_PID=$!
+
+sleep 0.5
+
+# ── 2. Create draft ─────────────────────────────────────────────
+echo "[draft] POST /api/v1/attestation/draft"
+DRAFT_RESPONSE=$(curl -s -X POST "$BASE/api/v1/attestation/draft" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"creator\": \"$CREATOR\",
+    \"intent\": \"Climate poster v1\",
+    \"tool\": \"midjourney/6.1\",
+    \"license\": \"CC-BY-4.0\"
+  }")
+
+ATTESTATION=$(echo "$DRAFT_RESPONSE" | jq -c '.attestation')
+ATT_ID=$(echo "$ATTESTATION" | jq -r '.id')
+echo "  attestation.id = $ATT_ID"
+
+# ── 3. Sign ──────────────────────────────────────────────────────
+echo "[sign] POST /api/v1/attestation/sign"
+SIGN_RESPONSE=$(curl -s -X POST "$BASE/api/v1/attestation/sign" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"attestation\": $ATTESTATION,
+    \"private_key_pem\": $(echo "$PRIVATE_KEY" | jq -Rs .)
+  }")
+
+SIGNED=$(echo "$SIGN_RESPONSE" | jq -c '.signed_attestation')
+SIG=$(echo "$SIGNED" | jq -r '.signature')
+echo "  signature = ${SIG:0:30}..."
+
+# ── 4. Verify ────────────────────────────────────────────────────
+echo "[verify] POST /api/v1/attestation/verify"
+VERIFY_RESPONSE=$(curl -s -X POST "$BASE/api/v1/attestation/verify" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"signed_attestation\": $SIGNED,
+    \"public_key_pem\": $(echo "$PUBLIC_KEY" | jq -Rs .)
+  }")
+
+VALID=$(echo "$VERIFY_RESPONSE" | jq -r '.result.valid')
+echo "  valid = $VALID"
+
+# ── 5. Renew ─────────────────────────────────────────────────────
+echo "[renew] POST /api/v1/attestation/renew"
+RENEW_RESPONSE=$(curl -s -X POST "$BASE/api/v1/attestation/renew" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"renews\": \"$ATT_ID\",
+    \"creator\": \"$CREATOR\",
+    \"intent\": \"Climate poster v2\",
+    \"private_key_pem\": $(echo "$PRIVATE_KEY" | jq -Rs .)
+  }")
+
+RENEWED_ID=$(echo "$RENEW_RESPONSE" | jq -r '.signed_attestation.attestation.id')
+RENEWS_FIELD=$(echo "$RENEW_RESPONSE" | jq -r '.signed_attestation.attestation.renews')
+echo "  new id = $RENEWED_ID"
+echo "  renews = $RENEWS_FIELD"
+
+# ── 6. Verify renewal ───────────────────────────────────────────
+echo "[verify] POST /api/v1/attestation/verify (renewal)"
+RENEWED_SIGNED=$(echo "$RENEW_RESPONSE" | jq -c '.signed_attestation')
+VERIFY2_RESPONSE=$(curl -s -X POST "$BASE/api/v1/attestation/verify" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"signed_attestation\": $RENEWED_SIGNED,
+    \"public_key_pem\": $(echo "$PUBLIC_KEY" | jq -Rs .)
+  }")
+
+VALID2=$(echo "$VERIFY2_RESPONSE" | jq -r '.result.valid')
+echo "  valid = $VALID2"
+
+# ── 7. Revoke original ──────────────────────────────────────────
+echo "[revoke] POST /api/v1/attestation/revoke"
+REVOKE_RESPONSE=$(curl -s -X POST "$BASE/api/v1/attestation/revoke" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"attestation_id\": \"$ATT_ID\",
+    \"reason\": \"Superseded by v2\",
+    \"private_key_pem\": $(echo "$PRIVATE_KEY" | jq -Rs .)
+  }")
+
+REVOKED_ID=$(echo "$REVOKE_RESPONSE" | jq -r '.revocation.revocation.attestation_id')
+echo "  revoked = $REVOKED_ID"
+
+# ── 8. Show captured SSE events ─────────────────────────────────
+sleep 0.5
+kill "$SSE_PID" 2>/dev/null || true
+wait "$SSE_PID" 2>/dev/null || true
+
+echo ""
+echo "=== SSE events captured ==="
+if [ -s "$TMPDIR/events.log" ]; then
+  cat "$TMPDIR/events.log"
+else
+  echo "  (no events — server may not emit SSE for REST calls)"
+fi
+
+echo ""
+echo "=== Done ==="

--- a/packages/arr-widget/README.md
+++ b/packages/arr-widget/README.md
@@ -2,29 +2,96 @@
 
 Injected browser overlay for in-context ARR attestations.
 
-Status: MVP selection + draft creation panel.
-Includes live event updates and renew/revoke helpers (prompt-driven).
+Status: MVP — selection capture, draft creation, renew/revoke, live SSE updates.
 
-## Usage (injected)
+## Quickstart
 
 ```js
 import { mountWidget } from "@allrightsrespected/widget";
 
-mountWidget({
+const widget = mountWidget({
   endpoint: "http://127.0.0.1:8787",
   toolVersion: "0.1.0",
 });
+
+// Remove when done
+widget.destroy();
 ```
 
-## Selection modes
-- Rect (drag)
-- Point (click)
-- Range (text selection)
-- Object (element target)
+### Constructor options
 
-## Dependencies
-- `@allrightsrespected/mcp/widget` for schemas + API paths.
+| Option           | Type     | Default                   | Description                          |
+| ---------------- | -------- | ------------------------- | ------------------------------------ |
+| `endpoint`       | `string` | `http://127.0.0.1:8787`  | ARR MCP server URL                   |
+| `toolVersion`    | `string` | `0.1.0`                  | Included in widget context as `arr-widget/<version>` |
+| `sessionId`      | `string` | `crypto.randomUUID()`    | Persisted per tab; sent with every request |
+| `initialCreator` | `string` | —                        | Pre-fills the creator input field    |
+
+## Selection modes
+
+Click a mode button in the overlay, then interact with the page.
+
+| Mode     | Gesture        | Required fields               | Optional fields          |
+| -------- | -------------- | ----------------------------- | ------------------------ |
+| **Rect** | Click + drag   | `bounds: [x, y, w, h]`       | `text`, `object_id`     |
+| **Point**| Click          | `bounds: [x, y, 0, 0]`       | `text`, `object_id`     |
+| **Range**| Text selection | `text` (non-empty)            | `bounds`, `object_id`   |
+| **Object**| Click element | `object_id` (CSS path or `data-arr-id`) | `bounds`, `text` |
+
+All selections are validated against the `widgetSelectionSchema` discriminated union at capture time.
+Invalid selections throw a Zod parse error.
+
+### Escape to cancel
+
+Press **Escape** during any selection mode to cancel without capturing.
+
+## Widget context
+
+Every request to the server includes a `WidgetContext` built from:
+
+```
+{
+  surface: "browser",
+  tool: "arr-widget/<toolVersion>",
+  file_path: window.location.href,
+  selection: <captured selection or omitted>,
+  session: <sessionId>
+}
+```
+
+Context is validated against `widgetContextSchema` before sending.
 
 ## Live updates
-- Subscribes to `GET /events` on the configured endpoint.
-- Updates widget state from SSE events via `EVENT_TO_STATE`.
+
+The widget subscribes to `GET /events` on the configured endpoint via `EventSource` (SSE).
+Incoming events update the widget state display:
+
+| SSE event type                   | Widget state    |
+| -------------------------------- | --------------- |
+| `arr.attestation.draft.created`  | `pending_sign`  |
+| `arr.attestation.signed`         | `signed`        |
+| `arr.attestation.published`      | `published`     |
+| `arr.attestation.verified`       | `verified`      |
+| `arr.attestation.renewed`        | `verified`      |
+| `arr.attestation.revoked`        | `idle`          |
+
+## Local development
+
+Build order matters — `arr-mcp` must build first because `arr-widget` imports
+from the `@allrightsrespected/mcp/widget` subpath export.
+
+```bash
+# From repo root
+npm run build --workspace @allrightsrespected/mcp
+npm run build --workspace @allrightsrespected/widget
+```
+
+Or use the root build script which handles ordering:
+
+```bash
+npm run build
+```
+
+## Dependencies
+
+- `@allrightsrespected/mcp/widget` — schemas, API paths, state machine, types.


### PR DESCRIPTION
## Summary
- Expanded `packages/arr-widget/README.md` with constructor options, selection mode required fields, widget context shape, SSE event mapping table, and build-order note
- Added `examples/smoke.sh` — full lifecycle smoke test via curl (draft → sign → verify → renew → verify → revoke) with background SSE listener

Pairs with Codex's branch `docs/interaction-layer-readmes` (root README + arr-mcp README). Both touch different files and can merge independently.

## Test plan
- [x] 90 tests green (no code changes, docs only)
- [ ] Run `./examples/smoke.sh` against a live server to verify curl commands


🤖 Generated with [Claude Code](https://claude.com/claude-code)